### PR TITLE
Fix `write` to `write_all`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "pack"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/package.rs
+++ b/src/package.rs
@@ -260,8 +260,8 @@ pub fn save(packs: Vec<Package>) -> Result<()> {
         fs::create_dir_all(&*PACK_CONFIG_DIR)?;
     }
     let mut f = File::create(&*PACK_FILE)?;
-    f.write(PACKFILE_HEADER)?;
-    f.write(out.as_bytes())?;
+    f.write_all(PACKFILE_HEADER)?;
+    f.write_all(out.as_bytes())?;
     Ok(())
 }
 


### PR DESCRIPTION
`write` just write part of the buffer(may be all) and return how many bytes was written.

btw, consider use `cargo clippy` to improve code quality.
https://github.com/rust-lang-nursery/rust-clippy