### PR TITLE
Fix installation failure handling

### DIFF
--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -140,7 +140,10 @@ fn install_plugins(plugins: &Plugins) -> Result<()> {
                 manager.add(pack);
             }
         }
-        manager.run(install_plugin);
+
+        for fail in manager.run(install_plugin) {
+            packs.retain(|e| e.name != fail);
+        }
     }
 
     packs.sort_by(|a, b| a.name.cmp(&b.name));

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -87,7 +87,10 @@ fn update_plugins(plugins: &[String], threads: usize, skip: &[String]) -> Result
             manager.add(pack.clone());
         }
     }
-    manager.run(update_plugin);
+
+    for fail in manager.run(update_plugin) {
+        packs.retain(|e| e.name != fail);
+    }
 
     packs.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::fs;
 
 use Result;
 use git2::{self, Repository};
@@ -17,7 +18,7 @@ fn fetch(repo: &Repository, name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn clone<P: AsRef<Path>>(name: &str, target: P) -> Result<()> {
+fn clone_real<P: AsRef<Path>>(name: &str, target: P) -> Result<()> {
     let repo = git2::Repository::init(&target)?;
     fetch(&repo, name)?;
     let reference = "HEAD";
@@ -26,6 +27,14 @@ pub fn clone<P: AsRef<Path>>(name: &str, target: P) -> Result<()> {
     repo.reset(&object, git2::ResetType::Hard, None)?;
     update_submodules(&repo)?;
     Ok(())
+}
+
+pub fn clone<P: AsRef<Path>>(name: &str, target: P) -> Result<()> {
+    let result = clone_real(name, &target);
+    if result.is_err() {
+        fs::remove_dir_all(&target)?;
+    }
+    result
 }
 
 pub fn update<P: AsRef<Path>>(name: &str, path: P) -> Result<()> {


### PR DESCRIPTION
Specifying a package which doesn't exsit (locally or remotely) will
fail to install. However, the git repo directory and the packfile will
still be updated/initialized with the specific package. This introduces
the appropriate failure handling.

* removes the `git init` created directory if nothing could be fetched
  form remote, or the directory does not exist locally
* fix package::repo path extraction (tests added)
* don't included failed repos from installation during during packfile
  generation