### PR TITLE
Add generate sub command

### DIFF
--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -1,0 +1,38 @@
+use Result;
+use package::{self};
+use docopt::Docopt;
+
+const USAGE: &str = "
+Generate the pack plugin file (_pack.vim) which combines all plugin configurations
+
+Usage:
+    pack generate [options]
+
+Options:
+    -h, --help              Display this message
+";
+
+#[derive(Debug, RustcDecodable)]
+struct GenerateArgs { }
+
+pub fn execute(args: &[String]) {
+    let mut argv = vec!["pack".to_string(), "generate".to_string()];
+    argv.extend_from_slice(args);
+
+    let _args: GenerateArgs =
+        Docopt::new(USAGE)
+            .and_then(|d| d.argv(argv).decode())
+            .unwrap_or_else(|e| e.exit());
+
+
+    let _ = update_packfile();
+}
+
+fn update_packfile() -> Result<()> {
+    let mut packs = package::fetch()?;
+
+    packs.sort_by(|a, b| a.name.cmp(&b.name));
+    package::update_pack_plugin(&packs)?;
+
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,3 +6,4 @@ pub mod config;
 pub mod move_cmd;
 pub mod uninstall;
 pub mod update;
+pub mod generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ Commands:
     config
     move
     update
+    generate
     version
 
 Options:
@@ -60,6 +61,7 @@ pub enum Command {
     Config,
     Move,
     Update,
+    Generate,
 }
 
 fn execute(cmd: &Command, argv: &[String]) {
@@ -76,13 +78,17 @@ fn execute(cmd: &Command, argv: &[String]) {
         Command::Config => cmd::config::execute(argv),
         Command::Move => cmd::move_cmd::execute(argv),
         Command::Update => cmd::update::execute(argv),
+        Command::Generate => cmd::generate::execute(argv),
     }
 }
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.options_first(true).decode())
-        .unwrap_or_else(|e| e.exit());
+        .unwrap_or_else(|_|{
+            println!("{}", USAGE);
+            std::process::exit(1)
+        });
 
     match args.arg_command {
         Some(ref c) => execute(c, &args.arg_args),


### PR DESCRIPTION
Instead of using sub command `update` to regenerate _pack.vim file, the
`generate` sub-command can now be used.