### PR TITLE
Show proper error when invalid package names are issued

### DIFF
--- a/src/cmd/move_cmd.rs
+++ b/src/cmd/move_cmd.rs
@@ -35,12 +35,12 @@ fn move_plugin(plugin: &str, category: &str, opt: bool) -> Result<()> {
     let changed = {
         let pack = match packs.iter_mut().find(|p| p.name == plugin) {
             Some(p) => p,
-            None => return Err(Error::PluginNotInstalled),
+            None => return Err(Error::plugin_not_installed(plugin)),
         };
 
         let origin_path = pack.path();
         if !origin_path.is_dir() {
-            return Err(Error::PluginNotInstalled);
+            return Err(Error::plugin_not_installed(plugin));
         }
 
         let path = package::Package::new(plugin, category, opt).path();

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -49,6 +49,9 @@ fn uninstall_plugins(plugins: &[String], all: bool) -> Result<()> {
     packs.sort_by(|a, b| a.name.cmp(&b.name));
     package::update_pack_plugin(&packs)?;
     package::save(packs)?;
+
+    println!();
+    println!("Uninstalled {}", plugins.join(", "));
     Ok(())
 }
 

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -95,7 +95,7 @@ fn update_plugin(pack: &Package) -> (Result<()>, bool) {
 fn do_update(pack: &Package) -> Result<()> {
     let path = pack.path();
     if !path.is_dir() {
-        Err(Error::PluginNotInstalled)
+        Err(Error::plugin_not_installed(&pack.name))
     } else if pack.local {
         Err(Error::SkipLocal)
     } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Git(String),
     Editor,
     Build(String),
-    PluginNotInstalled,
+    PluginNotInstalled(String),
     NoPlugin,
     SkipLocal,
     PluginInstalled(String),
@@ -39,6 +39,10 @@ impl Error {
 
     pub fn plugin_installed<T: AsRef<Path>>(s: T) -> Error {
         Error::PluginInstalled(format!("Plugin already installed under {:?}", s.as_ref()))
+    }
+
+    pub fn plugin_not_installed(s: &str) -> Error {
+        Error::PluginNotInstalled(format!("{} not installed", s))
     }
 }
 
@@ -85,7 +89,6 @@ impl StdError for Error {
             Error::SaveYaml => "Fail to save packfile",
             Error::LoadYaml => "Fail to load packfile",
             Error::Editor => "Can not open editor",
-            Error::PluginNotInstalled => "Plugin not installed",
             Error::NoPlugin => "Can not find such plugin",
             Error::SkipLocal => "Local plugin. Skipping",
             Error::Io(ref e) => e.description(),
@@ -93,6 +96,7 @@ impl StdError for Error {
             | Error::Git(ref s)
             | Error::CopyDir(ref s)
             | Error::PluginInstalled(ref s)
+            | Error::PluginNotInstalled(ref s)
             | Error::PackFile(ref s) => s,
         }
     }


### PR DESCRIPTION
Currently uninstalling a non existent plugin fails silently with exit status 0. This PR shows a concise error message when an invalid package name is supplied and also provides feedback after the plugins are uninstalled. I'm still learning and grappling with rust so there'll definitely be room for improvement :)